### PR TITLE
Fixed incorrectly using mutable fields(var) in api response data classes

### DIFF
--- a/app/src/main/java/com/example/credr/snapsearch/di/RepositoryModule.kt
+++ b/app/src/main/java/com/example/credr/snapsearch/di/RepositoryModule.kt
@@ -23,7 +23,7 @@ class RepositoryModule{
     @Singleton
     fun provideGson() : Gson{
         return GsonBuilder()
-                .excludeFieldsWithModifiers(Modifier.FINAL,Modifier.STATIC,Modifier.STATIC)
+                .excludeFieldsWithModifiers(Modifier.STATIC,Modifier.TRANSIENT)
                 .create()
     }
 

--- a/app/src/main/java/com/example/credr/snapsearch/results/model/Product.kt
+++ b/app/src/main/java/com/example/credr/snapsearch/results/model/Product.kt
@@ -4,12 +4,12 @@ package com.example.credr.snapsearch.results.model
  * Created by punitdama on 31/12/17.
  */
 data class Product(
-        var title : String,
-        var price : Long,
-        var sellingPrice : Long,
-        var imgs : List<String>? = null,
-        var avgRating : Float)
+        val title : String,
+        val price : Long,
+        val sellingPrice : Long,
+        val imgs : List<String>? = null,
+        val avgRating : Float)
 
-data class CustomSearchResultDto(var searchResultDTOMobile : SearchResultDTOMobile? = null)
+data class CustomSearchResultDto(val searchResultDTOMobile : SearchResultDTOMobile? = null)
 
-data class SearchResultDTOMobile(var catalogSearchDTOMobile : List<Product>? = null)
+data class SearchResultDTOMobile(val catalogSearchDTOMobile : List<Product>? = null)

--- a/app/src/main/java/com/example/credr/snapsearch/results/model/SearchResultsResponse.kt
+++ b/app/src/main/java/com/example/credr/snapsearch/results/model/SearchResultsResponse.kt
@@ -4,5 +4,5 @@ package com.example.credr.snapsearch.results.model
  * Created by punitdama on 31/12/17.
  */
 data class SearchResultsResponse(
-        var successful : Boolean = false,
-        var customSearchResultDto : CustomSearchResultDto? = null)
+        val successful : Boolean = false,
+        val customSearchResultDto : CustomSearchResultDto? = null)

--- a/app/src/main/java/com/example/credr/snapsearch/search/model/AutoSuggestion.kt
+++ b/app/src/main/java/com/example/credr/snapsearch/search/model/AutoSuggestion.kt
@@ -3,4 +3,4 @@ package com.example.credr.snapsearch.search.model
 /**
  * Created by punitdama on 31/12/17.
  */
-data class AutoSuggestion(var keyword : String,var categoryXPath : String?)
+data class AutoSuggestion(val keyword : String,val categoryXPath : String? = null)

--- a/app/src/main/java/com/example/credr/snapsearch/search/model/AutoSuggestionsResponse.kt
+++ b/app/src/main/java/com/example/credr/snapsearch/search/model/AutoSuggestionsResponse.kt
@@ -3,4 +3,4 @@ package com.example.credr.snapsearch.search.model
 /**
  * Created by punitdama on 31/12/17.
  */
-data class AutoSuggestionsResponse(var successful: Boolean, var responseAutosuggestions : List<AutoSuggestion>)
+data class AutoSuggestionsResponse(val successful: Boolean, val responseAutosuggestions : List<AutoSuggestion>)


### PR DESCRIPTION
- Changed all `vars` to `vals` in data classes used for representing api response.
- Used `vars` in first place because I thought `vals` don't work with Gson deserialization  😅
Reason they weren't working in first place because I have added `excludeFieldsWithModifiers(Modifier.FINAL)` when creating Gson object. 

Despite this mistake, there is one more issue when using Gson with data classes.
Non-nullable fields defined in data classes are initialized with null values because Gson uses reflection and puts nulls in a backing field whose property was declared as non-nullable.

Moshi and Jackson both fix this issue, so maybe we should try them out. 
Also, Gson is no longer actively maintained